### PR TITLE
fixed typos, missing error codes, missing input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ Output parameters:
  * `balances` - object describing the funds available on the user account, with the following properties:
    * `available` - object describing free funds available in each currency.
    * `blocked` - object describing funds in active trade offers, in each currency.
+ * `account` - object describing the state of the user account, with the following properties:
+   * `turnover` - account turnover value.
+   * `commissionMaker` - commission value as market maker.
+   * `commissionTaker` - commission value as market taker.
+ * `bank_deposit_fiat` - object describing information to deposit fiat currency, one for each. Currently only PLN and EUR:
+   * `PLN`
+     * `bank_name` - name of the bank where the deposit is to be made.
+     * `pay_to` - name to whom deposit is to be made.
+     * `acc_num` - the account number where deposit is to be made.
+     * `transfer_title` - text to identify the  deposit by the user.
+   * `EUR` - same as PLN with one additional data
+     * `swift_code` - the switch code to be used to transfer EURO
 
 <a name="api_trade"></a>
 ### `trade` - submit an order

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Error code | Error description
 504 | The key is not authoriced to use this API method
 505 | Invalid value of the `method` parameter
 506 | Too many commands in a given time interval
+507 | Invalid nonce value (only if an old request is sent again - replay attack)
 400 | Invalid value of the `market` parameter
 401 | Invalid value of the `type` parameter
 402 | Invalid value of the `amount` parameter
@@ -216,6 +217,9 @@ Error code | Error description
 412 | Invalid value of the `type` parameter.
 413 | Invalid value of the `rateLoss` parameter.
 414 | Invalid value of the `rateProfit` parameter.
+415 | Cannot close margin because the position is not fully open
+416 | Cannot cancel margin because the position is fully open
+417 | Order cannot be fully satisfied and all or nothing was requested (no longer in use)
 300 | Internal application error
 
 API method list
@@ -262,7 +266,7 @@ Output parameters:
 
 Please note that there are three possible scenarios when a trade is submitted:
 
- 1. The trade is executed immediately, because a matched order os already present on the orderbook. 
+ 1. The trade is executed immediately, because a matched order is already present on the orderbook. 
  In such case, the fields `id` and `order` will be empty, because no order is submitted in the orderbook.
  The `balances` field indicates the new account balances after the trade.
  2. The trade is partially executed. In such case the `order` field will describe the partial order submitted in the orderbook.
@@ -493,6 +497,7 @@ Output parameters:
 Input parameters:
 
  * `id` - contract identifier.
+ * `currency` - cryptocurrency code (like "*BTC*").
 
 Output parameters:
 


### PR DESCRIPTION
Put missing error codes that I found in the /api2/errors.php.

There was also a typo in the line: 
The trade is executed immediately, because a matched order os already present on the orderbook
This I changed to:
The trade is executed immediately, because a matched order is already present on the orderbook

In the description of api method 'closeSwap', the required input parameter 'currency' was missing. I put that in the input section.

Updated the "info" API method description to include the deposit information.